### PR TITLE
Fix #17:  .cmake-tidy.json file can override only subset of options

### DIFF
--- a/cmake_tidy/formatting/__init__.py
+++ b/cmake_tidy/formatting/__init__.py
@@ -5,15 +5,17 @@ from cmake_tidy.formatting.cmake_formatter import CMakeFormatter
 
 
 def load_format_settings() -> dict:
+    settings = _get_default_format_settings()
+    settings.update(_read_settings())
+    return settings
+
+
+def _read_settings():
     settings_file = Path.cwd() / '.cmake-tidy.json'
     if settings_file.exists():
-        return _read_settings(settings_file)
-    return _get_default_format_settings()
-
-
-def _read_settings(settings_file):
-    with settings_file.open() as file:
-        return json.load(file)
+        with settings_file.open() as file:
+            return json.load(file)
+    return dict()
 
 
 def _get_default_format_settings() -> dict:

--- a/tests/integration/approved_files/TestCMakeTidyFormat.test_format_should_dump_full_config_even_if_file_overrides_only_one.approved.txt
+++ b/tests/integration/approved_files/TestCMakeTidyFormat.test_format_should_dump_full_config_even_if_file_overrides_only_one.approved.txt
@@ -1,0 +1,12 @@
+{
+  "succeeding_newlines": 2,
+  "tabs_as_spaces": false,
+  "tab_size": 4,
+  "force_command_lowercase": true,
+  "space_between_command_and_begin_parentheses": false,
+  "line_length": 80,
+  "wrap_short_invocations_to_single_line": false,
+  "closing_parentheses_in_newline_when_splitted": false,
+  "unquoted_uppercase_as_keyword": false,
+  "keywords": []
+}

--- a/tests/integration/test_cmake_tidy_format.py
+++ b/tests/integration/test_cmake_tidy_format.py
@@ -26,6 +26,13 @@ class TestCMakeTidyFormat(TestIntegrationBase):
         normalized_output = normalize(stdout.getvalue())
         verify(normalized_output, self.reporter)
 
+    @mock.patch('cmake_tidy.formatting._read_settings', return_value={'tabs_as_spaces': False})
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_format_should_dump_full_config_even_if_file_overrides_only_one(self, stdout, file_settings):
+        self.assertSuccess(execute_cmake_tidy(command='format', arguments=['--dump-config', 'dummy.txt']))
+        normalized_output = normalize(stdout.getvalue())
+        verify(normalized_output, self.reporter)
+
     @mock.patch('cmake_tidy.commands.format.output_writer.OutputWriter.write')
     def test_format_inplace_simple_file(self, write):
         self.assertSuccess(execute_cmake_tidy(command='format', arguments=['-i', get_input_file('arguments.cmake')]))


### PR DESCRIPTION
application should correctly fill others with default values. Integration test checking corresponding functionality introduced as well